### PR TITLE
Fix Window{Back,Forward} tokens not being verified properly

### DIFF
--- a/totp.go
+++ b/totp.go
@@ -71,8 +71,9 @@ func (t *TOTP) Now() *TOTP {
 func (t TOTP) Verify(token string) bool {
 	t.setDefaults()
 	t.normalize()
+	givenTime := t.Time
 	for i := int(t.WindowBack) * -1; i <= int(t.WindowForward); i++ {
-		t.Time = t.Time.Add(time.Second * time.Duration(int(t.Period)*i))
+		t.Time = givenTime.Add(time.Second * time.Duration(int(t.Period)*i))
 		if t.Get() == token {
 			return true
 		}

--- a/totp_test.go
+++ b/totp_test.go
@@ -74,3 +74,31 @@ func TestTOTPVerifyShouldFail(t *testing.T) {
 	token := totp.Get()
 	assert.False(t, totp.Now().Verify(token))
 }
+
+func TestTOTPVerifyShouldSucceedWithinWindowForward(t *testing.T) {
+	future := time.Now().Add(time.Second * DefaultPeriod * 3)
+	totp := &TOTP{Time: future, WindowForward: 3}
+	token := totp.Get()
+	assert.True(t, totp.Now().Verify(token))
+}
+
+func TestTOTPVerifyShouldSucceedWithinWindowBack(t *testing.T) {
+	past := time.Now().Add(time.Second * DefaultPeriod * -3)
+	totp := &TOTP{Time: past, WindowBack: 3}
+	token := totp.Get()
+	assert.True(t, totp.Now().Verify(token))
+}
+
+func TestTOTPVerifyShouldFailOutOfWindowForward(t *testing.T) {
+	future := time.Now().Add(time.Second * DefaultPeriod * 4)
+	totp := &TOTP{Time: future, WindowForward: 3}
+	token := totp.Get()
+	assert.False(t, totp.Now().Verify(token))
+}
+
+func TestTOTPVerifyShouldFailOutOfWindowBack(t *testing.T) {
+	past := time.Now().Add(time.Second * DefaultPeriod * -4)
+	totp := &TOTP{Time: past, WindowBack: 3}
+	token := totp.Get()
+	assert.False(t, totp.Now().Verify(token))
+}


### PR DESCRIPTION
When initializing Totp with the given Window{Back,Forward} the verification of the generated tokens within that window fails. 

The for loop that goes through the matching tokens using the given Window{Back,Forward} always updates the Totp's Time variable with the preceding value of Time, resulting in a Moving Window generating wrong tokens.

It's my pleasure to contribute, please give me any possible feedback for the tests provided in this PR as I'm newly introduced to GO ;)
