### PR TITLE
Handle padding on base32 secrets

### DIFF
--- a/hotp.go
+++ b/hotp.go
@@ -46,7 +46,13 @@ func (h *HOTP) Get() string {
 	text := counterToBytes(h.Counter)
 	var hash []byte
 	if h.IsBase32Secret {
-		secretBytes, _ := base32.StdEncoding.DecodeString(h.Secret)
+		secret := h.Secret
+		for len(secret)%8 != 0 {
+			secret = secret + "="
+		}
+		fmt.Println(h.Secret)
+		fmt.Println(secret)
+		secretBytes, _ := base32.StdEncoding.DecodeString(secret)
 		hash = hmacSHA1(secretBytes, text)
 	} else {
 		hash = hmacSHA1([]byte(h.Secret), text)


### PR DESCRIPTION
This should handle #7 by padding out the Base32 string to always be a multiple of 8 characters in length.

That said, it feels like a dangerous spot to hide the errors from base32 decoding the secret. Fixing that would require changing the API such that Get() (and thus the TOTP validate calls as well) would return an error in addition to their existing result.